### PR TITLE
Use https to clone from github

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Basher allows you to quickly install bash packages directly from github. Instead
 1. Checkout basher on `~/.basher`
 
     ~~~ sh
-    $ git clone git://github.com/basherpm/basher.git ~/.basher
+    $ git clone https://github.com/basherpm/basher.git ~/.basher
     ~~~
 
 2. Add `~/.basher/bin` to `$PATH` for easy access to the basher command-line utility.

--- a/libexec/basher-_clone
+++ b/libexec/basher-_clone
@@ -34,4 +34,4 @@ if [ -e "$BASHER_PACKAGES_PATH/$package" ]; then
   exit 1
 fi
 
-git clone "git://github.com/$package.git" "${BASHER_PACKAGES_PATH}/$package"
+git clone "https://github.com/$package.git" "${BASHER_PACKAGES_PATH}/$package"

--- a/tests/basher-_clone.bats
+++ b/tests/basher-_clone.bats
@@ -34,5 +34,5 @@ load test_helper
 
   run basher-_clone username/package
   assert_success
-  assert_output "git clone git://github.com/username/package.git ${BASHER_PACKAGES_PATH}/username/package"
+  assert_output "git clone https://github.com/username/package.git ${BASHER_PACKAGES_PATH}/username/package"
 }


### PR DESCRIPTION
Use encrypted https instead of the git protocol to clone repos from to
make man-in-the-middle attacks harder.
