### PR TITLE
Use /111 instead of +111 to specify find perms

### DIFF
--- a/libexec/basher-_link-bins
+++ b/libexec/basher-_link-bins
@@ -20,7 +20,7 @@ if [ -e "$BASHER_PACKAGES_PATH/$package/bin" ]; then
   exit 0
 fi
 
-bins=($(find "$BASHER_PACKAGES_PATH/$package" -maxdepth 1 -perm +111 -type f -or -type l))
+bins=($(find "$BASHER_PACKAGES_PATH/$package" -maxdepth 1 -perm /111 -type f -or -type l))
 bins=("${bins[@]##*/}")
 
 for bin in "${bins[@]}"

--- a/libexec/basher-_unlink-bins
+++ b/libexec/basher-_unlink-bins
@@ -16,7 +16,7 @@ if [ -e "$BASHER_PACKAGES_PATH/$package/bin" ]; then
   exit 0
 fi
 
-bins=($(find "$BASHER_PACKAGES_PATH/$package" -maxdepth 1 -perm +111 -type f -or -type l))
+bins=($(find "$BASHER_PACKAGES_PATH/$package" -maxdepth 1 -perm /111 -type f -or -type l))
 bins=("${bins[@]##*/}")
 
 for bin in "${bins[@]}"


### PR DESCRIPTION
The '+111' format is deprecated since 2005 and does not work on Fedora 20.
