### PR TITLE
Clone with --depth=1 for faster downloading

### DIFF
--- a/libexec/basher-_clone
+++ b/libexec/basher-_clone
@@ -34,4 +34,4 @@ if [ -e "$BASHER_PACKAGES_PATH/$package" ]; then
   exit 0
 fi
 
-git clone --recursive "https://github.com/$package.git" "${BASHER_PACKAGES_PATH}/$package"
+git clone --depth=1 --recursive "https://github.com/$package.git" "${BASHER_PACKAGES_PATH}/$package"

--- a/tests/basher-_clone.bats
+++ b/tests/basher-_clone.bats
@@ -34,5 +34,5 @@ load test_helper
 
   run basher-_clone username/package
   assert_success
-  assert_output "git clone --recursive https://github.com/username/package.git ${BASHER_PACKAGES_PATH}/username/package"
+  assert_output "git clone --depth=1 --recursive https://github.com/username/package.git ${BASHER_PACKAGES_PATH}/username/package"
 }


### PR DESCRIPTION
For git repositories with very long histories, it's much faster to
download with --depth=1 to limit how many extra pieces of history are
included.  After all, we only care about the content, not history.