### PR TITLE
feature: make functions sourceable in current shell

### DIFF
--- a/libexec/basher
+++ b/libexec/basher
@@ -22,32 +22,37 @@ abs_dirname() {
   cd "$cwd"
 }
 
-if [ -z "$BASHER_ROOT" ]; then
-  BASHER_ROOT="$HOME/.basher"
-fi
-export BASHER_ROOT
-
-if [ -z "$BASHER_PACKAGES_PATH" ]; then
-  BASHER_PACKAGES_PATH="$BASHER_ROOT/cellar/packages"
-fi
-export BASHER_PACKAGES_PATH
-
-bin_path="$(abs_dirname "$0")"
-export PATH="${bin_path}:${PATH}"
-
-command="$1"
-case "$command" in
-"")
-  basher-help
-  ;;
-* )
-  command_path="$(command -v "basher-$command" || true)"
-  if [ -z "$command_path" ]; then
-    echo "basher: no such command '$command'" >&2
-    exit 1
+main() {
+  if [ -z "$BASHER_ROOT" ]; then
+    BASHER_ROOT="$HOME/.basher"
   fi
+  export BASHER_ROOT
 
-  shift 1
-  exec "$command_path" "$@"
-  ;;
-esac
+  if [ -z "$BASHER_PACKAGES_PATH" ]; then
+    BASHER_PACKAGES_PATH="$BASHER_ROOT/cellar/packages"
+  fi
+  export BASHER_PACKAGES_PATH
+
+  bin_path="$(abs_dirname "$0")"
+  export PATH="${bin_path}:${PATH}"
+
+  command="$1"
+  case "$command" in
+  "")
+    basher-help
+    ;;
+  * )
+    command_path="$(command -v "basher-$command" || true)"
+    if [ -z "$command_path" ]; then
+      echo "basher: no such command '$command'" >&2
+      exit 1
+    fi
+
+    shift 1
+    exec "$command_path" "$@"
+    ;;
+  esac
+}
+
+return 0 2>/dev/null || true
+main "$@"


### PR DESCRIPTION
Not sure if this is what you meant in https://github.com/basherpm/basher/issues/15, but this is a handy technique I found for making scripts sourceable.

It relies on the fact that when a script is sourced, the "return" keyword stops the sourcing.  So this cuts off execution before "main" is called, just leaving the functions defined in the current shell.

When the script is run as a command, the "return" keyword throws an error instead.  The "2>/dev/null" just hides the error and the script continues, calling "main".

The "|| true" appended to the return just allows the script to run even if bash's errexit option is set (set -e or set -o errexit).  The || true just gives that line a successful return code so it can continue executing.