### PR TITLE
feat: allow user to specify ssh or https access to an alternate site …

### DIFF
--- a/libexec/basher-_clone
+++ b/libexec/basher-_clone
@@ -5,17 +5,25 @@
 
 set -e
 
-if [ "$#" -ne 1 ]; then
+if [ "$#" -lt 1 ]; then
   basher-help _clone
   exit 1
 fi
 
-package="$1"
+package=$1
 
 if [ -z "$package" ]; then
   basher-help _clone
   exit 1
 fi
+
+site=${2:-github.com}
+proto=https
+
+[[ $site == *@* ]] && {
+  IFS=@ read -r login site <<< "$site"
+  proto=ssh
+}
 
 IFS=/ read -r user name <<< "$package"
 
@@ -34,4 +42,6 @@ if [ -e "$BASHER_PACKAGES_PATH/$package" ]; then
   exit 0
 fi
 
-git clone --depth=1 --recursive "https://github.com/$package.git" "${BASHER_PACKAGES_PATH}/$package"
+[[ $proto == "ssh" ]] && repo=$login${login:+@}$site: || repo=$proto://$site/
+
+git clone --depth=1 --recursive "$repo$package".git "${BASHER_PACKAGES_PATH}/$package"

--- a/libexec/basher-install
+++ b/libexec/basher-install
@@ -16,6 +16,8 @@ if [ -z "$package" ]; then
   exit 1
 fi
 
+[[ $package == *:* ]] && IFS=: read -r site package <<< "$package"
+
 IFS=/ read -r user name <<< "$package"
 
 if [ -z "$user" ]; then
@@ -28,7 +30,7 @@ if [ -z "$name" ]; then
   exit 1
 fi
 
-basher-_clone "$package"
+basher-_clone "$package" "$site"
 basher-_deps "$package"
 basher-_link-bins "$package"
 basher-_link-man "$package"


### PR DESCRIPTION
…such as bitbucket

Only affects the install command, all others don't need to change.

Defaults to the same syntax as before, goes to github https if not otherwise specified.

Extended syntax complies with git ssh access syntax (git@site.com:user/name), uses colon to separate server from repo path.  Https access is like so:

bitbucket.org:user/name

Ssh access is triggered by the presence of the @ sign like so:

git@bitbucket.org:user/name

Does not work for specifying dependencies in package.sh since : is already used as a separator.  I've got no plans for fixing this.

Cheers,

Ted
