### PR TITLE
fish completion: [optimize] use hard coded command

### DIFF
--- a/completions/basher.fish
+++ b/completions/basher.fish
@@ -17,6 +17,8 @@ function __fish_basher_using_command
 end
 
 complete -f -c basher -n '__fish_basher_needs_command' -a '(basher commands)'
-for cmd in (basher commands)
+set --local basher_commands commands completions help init \
+    install link list outdated package-path uninstall update upgrade
+for cmd in $basher_commands
   complete -f -c basher -n "__fish_basher_using_command $cmd" -a "(basher completions $cmd)"
 end


### PR DESCRIPTION
In fish completion, invoking `basher commands` to get command list
is slow. This commit uses hard coded command list to speed up fish
shell startup.

Some profiling data on my machine:

Before:

501     48814     ------>  for cmd in (basher commands)...
46563   46563   ------>  basher commands

After:

41  41   ---> set --local basher_commands commands completions help init
                       install link list outdated package-path uninstall update upgrade
111 879 ---> for cmd in $basher_commands...

---

 completions/basher.fish | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)
