### PR TITLE
Not use symbolic link for Windows compatibility.

### DIFF
--- a/bin/basher
+++ b/bin/basher
@@ -1,1 +1,2 @@
-../libexec/basher
+#/bin/sh
+$(dirname $0)/../libexec/basher


### PR DESCRIPTION
`bin/basher` was an symbolic link to `libexec/basher`,
which does not work on Windows (Windows does not support symbolic link).
This commit fix this issue by invoking `libexec/basher` from
`bin/basher` instead.

---