### PR TITLE
Redirect error messages to stderr and make variable scope local.

### DIFF
--- a/lib/include.dash
+++ b/lib/include.dash
@@ -1,0 +1,1 @@
+. "$BASHER_ROOT/lib/include.sh"

--- a/lib/include.sh
+++ b/lib/include.sh
@@ -1,21 +1,21 @@
 include() {
-  package="$1"
-  file="$2"
+  declare package="$1"
+  declare file="$2"
 
   if [ -z "$package" ] || [ -z "$file" ]; then
-    echo "Usage: include <package> <file>"
+    echo "Usage: include <package> <file>" >&2
     return 1
   fi
 
   if [ ! -e "$BASHER_PREFIX/packages/$package" ]; then
-    echo "Package not installed: $package"
+    echo "Package not installed: $package" >&2
     return 1
   fi
 
   if [ -e "$BASHER_PREFIX/packages/$package/$file" ]; then
-    source "$BASHER_PREFIX/packages/$package/$file"
+    source "$BASHER_PREFIX/packages/$package/$file" >&2
   else
-    echo "File not found: $BASHER_PREFIX/packages/$package/$file"
+    echo "File not found: $BASHER_PREFIX/packages/$package/$file" >&2
     return 1
   fi
 }

--- a/lib/include.sh
+++ b/lib/include.sh
@@ -1,6 +1,6 @@
 include() {
-  declare package="$1"
-  declare file="$2"
+  local package="$1"
+  local file="$2"
 
   if [ -z "$package" ] || [ -z "$file" ]; then
     echo "Usage: include <package> <file>" >&2
@@ -13,7 +13,7 @@ include() {
   fi
 
   if [ -e "$BASHER_PREFIX/packages/$package/$file" ]; then
-    source "$BASHER_PREFIX/packages/$package/$file" >&2
+    . "$BASHER_PREFIX/packages/$package/$file" >&2
   else
     echo "File not found: $BASHER_PREFIX/packages/$package/$file" >&2
     return 1

--- a/libexec/basher-init
+++ b/libexec/basher-init
@@ -48,11 +48,11 @@ case "$shell" in
 esac
 
 if [ -e "$BASHER_ROOT/lib/include.$shell" ]; then
-  echo "source \"\$BASHER_ROOT/lib/include.$shell\""
+  echo ". \"\$BASHER_ROOT/lib/include.$shell\""
 fi
 
 if [ -e "$BASHER_ROOT/completions/basher.$shell" ]; then
-  echo "source \"\$BASHER_ROOT/completions/basher.$shell\""
+  echo ". \"\$BASHER_ROOT/completions/basher.$shell\""
 fi
 
 case "$shell" in

--- a/tests/basher-init.bats
+++ b/tests/basher-init.bats
@@ -28,7 +28,7 @@ load test_helper
 
 @test "setup include function if it exists" {
   run basher-init - bash
-  assert_line -n 4 'source "$BASHER_ROOT/lib/include.bash"'
+  assert_line -n 4 '. "$BASHER_ROOT/lib/include.bash"'
 }
 
 @test "doesn't setup include function if it doesn't exist" {
@@ -39,7 +39,7 @@ load test_helper
 @test "setup basher completions if available" {
   run basher-init - bash
   assert_success
-  assert_line -n 5 'source "$BASHER_ROOT/completions/basher.bash"'
+  assert_line -n 5 '. "$BASHER_ROOT/completions/basher.bash"'
 }
 
 @test "does not setup basher completions if not available" {
@@ -60,3 +60,14 @@ load test_helper
   assert_success
   assert_line -n 6 'fpath=("$BASHER_ROOT/cellar/completions/zsh" $fpath)'
 }
+
+hasShell() {
+  which "$1" &>>/dev/null
+}
+
+@test "is sh-compatible" {
+  hasShell sh || skip "sh was not found in path."
+  run sh -ec 'eval "$(basher init - sh)"'
+  assert_success
+}
+


### PR DESCRIPTION
- By redirecting the error messages to stderr, it will be clear for the user what went wrong even when
  piping stdout through another program or capturing its output in a subshell.
- By making the variable scope local the shell's global state remains untouched.