### PR TITLE
Changes `sstephenson/bats` to `bats-core/bats-core`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
-install: git clone https://github.com/sstephenson/bats.git
+install: git clone https://github.com/bats-core/bats-core.git
 before_script:
   - git config --global user.email "user@example.com"
   - git config --global user.name "User Name"
-script: bats/bin/bats --tap tests
+script: bats-core/bin/bats --tap tests
 # skips unnecessary Ruby-specific setup
 language: c
 sudo: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Write a [good commit message][commit].
 
 ## Use the test suite
 
-To run the tests, make sure [bats](https://github.com/sstephenson/bats) is
+To run the tests, make sure [bats](https://github.com/bats-core/bats-core) is
 installed and run:
 
 ```

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ Run `basher update` to update basher.
 ### Installing packages from github.com
 
 ~~~ sh
-$ basher install sstephenson/bats
+$ basher install bats-core/bats-core
 ~~~
 
-This will install bats from https://github.com/sstephenson/bats and add `bin/bats` to the PATH.
+This will install bats from https://github.com/bats-core/bats-core and add `bin/bats` to the PATH.
 
 ### Installing packages from other sites
 
@@ -138,6 +138,7 @@ above.
 
 ## Working packages
 
+- [bats-core/bats-core](https://github.com/bats-core/bats-core)
 - [bltavares/kickstart](https://github.com/bltavares/kickstart)
 - [bripkens/dock](https://github.com/bripkens/dock)
 - [juanibiapina/gg](https://github.com/juanibiapina/gg)
@@ -145,7 +146,6 @@ above.
 - [juanibiapina/todo](https://github.com/juanibiapina/todo)
 - [pote/gpm](https://github.com/pote/gpm)
 - [pote/gvp](https://github.com/pote/gvp)
-- [sstephenson/bats](https://github.com/sstephenson/bats)
 - [tj/git-extras](https://github.com/tj/git-extras)
 - [jimeh/tmuxifier](https://github.com/jimeh/tmuxifier)
 - [treyhunner/tmuxstart](https://github.com/treyhunner/tmuxstart)
@@ -157,7 +157,7 @@ And many others. If a repo doesn't work, create an issue or a pull request.
 To run the tests, install bats:
 
 ~~~ sh
-$ basher install sstephenson/bats
+$ basher install bats-core/bats-core
 ~~~
 
 update submodules:


### PR DESCRIPTION
As [active development of BATS has moved](https://github.com/sstephenson/bats/issues/236) to [`bats-core`](https://github.com/bats-core/bats-core), it seemed prudent to change mentions of `sstephenson/bats` to `bats-core/bats-core`.