### PR TITLE
Fixed fish init syntax

### DIFF
--- a/libexec/basher-init
+++ b/libexec/basher-init
@@ -13,12 +13,12 @@ if [ -z "$shell" ]; then
 fi
 
 print_fish_commands() {
-  echo "setenv BASHER_SHELL $shell"
-  echo "setenv BASHER_ROOT $BASHER_ROOT"
-  echo "setenv BASHER_PREFIX $BASHER_PREFIX"
+  echo "set -gx BASHER_SHELL $shell"
+  echo "set -gx BASHER_ROOT $BASHER_ROOT"
+  echo "set -gx BASHER_PREFIX $BASHER_PREFIX"
 
   echo 'if not contains $BASHER_ROOT/cellar/bin $PATH'
-  echo 'setenv PATH $BASHER_ROOT/cellar/bin $PATH'
+  echo 'set -gx PATH $BASHER_ROOT/cellar/bin $PATH'
   echo 'end'
 }
 


### PR DESCRIPTION
Using the init script `status --is-interactive; and . (basher init -|psub)` currently results in:
```
setenv: Too many arguments
```
The usage of `setenv` does not suppose to support multiple args (it was supporting invalid syntax before v2.6.0, see [fish-shell issue](https://github.com/fish-shell/fish-shell/issues/4103#issuecomment-306356405))

The result is `setenv` complaining too many argument, similar issue present in [here](https://github.com/rbenv/rbenv/issues/1010).

The fix is changing `setenv` to `set -gx`, which is critical in line 21 (since there are multiple arguments)

----

An unrelated comment, it would be better to change instruction of `. (basher init -|psub)` to `source (basher init -|psub)` since `.` is deprecated (although it still works).
