### PR TITLE
Improve link command

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ access to the site, use `--ssh` to override the protocol:
 $ basher install --ssh juanibiapina/gg
 ~~~
 
+### Installing a local package
+
+If you develop a package locally and want to try it through basher,
+use the `link` command:
+
+~~~ sh
+$ basher link my_package my_namespace/my_package
+~~~
+
 ### Sourcing files from a package into current shell
 
 Basher provides an `include` function that allows sourcing files into the

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ If you develop a package locally and want to try it through basher,
 use the `link` command:
 
 ~~~ sh
-$ basher link my_package my_namespace/my_package
+$ basher link directory my_namespace/my_package
 ~~~
 
 ### Sourcing files from a package into current shell

--- a/libexec/basher-link
+++ b/libexec/basher-link
@@ -4,6 +4,10 @@
 
 set -e
 
+resolve_link() {
+  $(type -p greadlink readlink | head -n1) -e "$1"
+}
+
 if [ "$#" -ne 2 ]; then
   basher-help link
   exit 1
@@ -36,7 +40,7 @@ fi
 
 if [ -d "${BASHER_PACKAGES_PATH}/$package" ]; then
   echo "Package '$package' is already present"
-  exit 0
+  exit 1
 fi
 
 # Make sure the namespace directory exists before linking
@@ -45,9 +49,11 @@ if [ ! -d "${BASHER_PACKAGES_PATH}/$namespace" ]; then
 fi
 
 # Resolve local package path
-directory="$(readlink -e "$directory")"
+directory="$(resolve_link "$directory")"
 
 ln -s "$directory" "${BASHER_PACKAGES_PATH}/$package"
 
 basher-_link-bins "$package"
 basher-_link-completions "$package"
+basher-_link-man "$package"
+basher-_deps "$package"

--- a/libexec/basher-link
+++ b/libexec/basher-link
@@ -1,23 +1,53 @@
 #!/usr/bin/env bash
 # Summary: Installs a local directory as a basher package
-# Usage: basher link <directory>
+# Usage: basher link <directory> <package>
 
 set -e
 
-if [ "$#" -ne 1 ]; then
+if [ "$#" -ne 2 ]; then
   basher-help link
   exit 1
 fi
 
 directory="$1"
+package="$2"
 
 if [ ! -d "$directory" ]; then
   echo "Directory '$directory' not found."
   exit 1
 fi
 
-mkdir -p "${BASHER_PACKAGES_PATH}/link"
-ln -s "$(pwd)/$directory" "${BASHER_PACKAGES_PATH}/link/$directory"
+if [ -z "$package" ]; then
+  basher-help link
+  exit 1
+fi
 
-basher-_link-bins "link/$directory"
-basher-_link-completions "link/$directory"
+IFS=/ read -r namespace name <<< "$package"
+
+if [ -z "$namespace" ]; then
+  basher-help link
+  exit 1
+fi
+
+if [ -z "$name" ]; then
+  basher-help link
+  exit 1
+fi
+
+if [ -d "${BASHER_PACKAGES_PATH}/$package" ]; then
+  echo "Package '$package' is already present"
+  exit 0
+fi
+
+# Make sure the namespace directory exists before linking
+if [ ! -d "${BASHER_PACKAGES_PATH}/$namespace" ]; then
+  mkdir -p "${BASHER_PACKAGES_PATH}/$namespace"
+fi
+
+# Resolve local package path
+directory="$(readlink -e "$directory")"
+
+ln -s "$directory" "${BASHER_PACKAGES_PATH}/$package"
+
+basher-_link-bins "$package"
+basher-_link-completions "$package"

--- a/tests/basher-link.bats
+++ b/tests/basher-link.bats
@@ -46,26 +46,59 @@ load test_helper
 @test "links the package to packages under the correct namespace" {
   mock_command basher-_link-bins
   mock_command basher-_link-completions
+  mock_command basher-_link-man
+  mock_command basher-_deps
   mkdir package1
   run basher-link package1 namespace1/package1
   assert_success
   assert [ "$(readlink $BASHER_PACKAGES_PATH/namespace1/package1)" = "$(pwd)/package1" ]
 }
 
-@test "calls link-bins" {
+@test "calls link-bins, link-completions, link-man and deps" {
   mock_command basher-_link-bins
   mock_command basher-_link-completions
+  mock_command basher-_link-man
+  mock_command basher-_deps
   mkdir package2
   run basher-link package2 namespace2/package2
   assert_success
   assert_line "basher-_link-bins namespace2/package2"
+  assert_line "basher-_link-completions namespace2/package2"
+  assert_line "basher-_link-man namespace2/package2"
+  assert_line "basher-_deps namespace2/package2"
 }
 
-@test "calls link-completions" {
+@test "resolves current directory (dot) path" {
   mock_command basher-_link-bins
   mock_command basher-_link-completions
-  mkdir package2
-  run basher-link package2 namespace2/package2
+  mock_command basher-_link-man
+  mock_command basher-_deps
+  mkdir package3
+  cd package3
+  run basher-link . namespace3/package3
   assert_success
-  assert_line "basher-_link-completions namespace2/package2"
+  assert [ "$(readlink $BASHER_PACKAGES_PATH/namespace3/package3)" = "$(pwd)" ]
+}
+
+@test "resolves parent directory (dotdot) path" {
+  mock_command basher-_link-bins
+  mock_command basher-_link-completions
+  mock_command basher-_link-man
+  mock_command basher-_deps
+  mkdir package3
+  cd package3
+  run basher-link ../package3 namespace3/package3
+  assert_success
+  assert [ "$(readlink $BASHER_PACKAGES_PATH/namespace3/package3)" = "$(pwd)" ]
+}
+
+@test "resolves arbitrary complex relative path" {
+  mock_command basher-_link-bins
+  mock_command basher-_link-completions
+  mock_command basher-_link-man
+  mock_command basher-_deps
+  mkdir package3
+  run basher-link ./package3/.././package3 namespace3/package3
+  assert_success
+  assert [ "$(readlink $BASHER_PACKAGES_PATH/namespace3/package3)" = "$(pwd)/package3" ]
 }


### PR DESCRIPTION
This PR improves the link command:

- add support for absolute or relative path for the directory argument
- add a second argument to precise the installation namespace and name
- update tests
- add note about link command usage in the README