### PR TITLE
Implicit use of 'master' branch unless another is specified.

### DIFF
--- a/libexec/basher-install
+++ b/libexec/basher-install
@@ -50,7 +50,7 @@ fi
 if [[ "$package" = */*@* ]]; then
   IFS=@ read -r package ref <<< "$package"
 else
-  ref=""
+  ref="master"
 fi
 
 if [ -z "$ref" ]; then


### PR DESCRIPTION
Hi @juanibiapina,

This is to make provision for those following this gitflow model in https://nvie.com/posts/a-successful-git-branching-model/ where 'develop' is used and isn't stable.

Let me know if that's acceptable or if you have more clarifications.

Thanks.