### PR TITLE
[WIP] Add --no-deps option to link command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ use the `link` command:
 $ basher link directory my_namespace/my_package
 ~~~
 
+The `link` command will install the dependencies of local package.
+You can prevent that with the `--no-deps` option:
+
+~~~ sh
+$ basher link --no-deps directory my_namespace/my_package
+~~~
+
 ### Sourcing files from a package into current shell
 
 Basher provides an `include` function that allows sourcing files into the

--- a/libexec/basher-link
+++ b/libexec/basher-link
@@ -1,12 +1,23 @@
 #!/usr/bin/env bash
 # Summary: Installs a local directory as a basher package
-# Usage: basher link <directory> <package>
+# Usage: basher link [--no-deps] <directory> <package>
 
 set -e
 
 resolve_link() {
   $(type -p greadlink readlink | head -n1) -e "$1"
 }
+
+no_deps="false"
+
+for i in "$@"; do
+  case $i in
+    --no-deps)
+    no_deps="true"
+    shift
+    ;;
+  esac
+done
 
 if [ "$#" -ne 2 ]; then
   basher-help link
@@ -56,4 +67,7 @@ ln -s "$directory" "${BASHER_PACKAGES_PATH}/$package"
 basher-_link-bins "$package"
 basher-_link-completions "$package"
 basher-_link-man "$package"
-basher-_deps "$package"
+
+if [ "$no_deps" = "false" ]; then
+  basher-_deps "$package"
+fi

--- a/tests/basher-link.bats
+++ b/tests/basher-link.bats
@@ -5,13 +5,13 @@ load test_helper
 @test "without arguments prints usage" {
   run basher-link
   assert_failure
-  assert_line "Usage: basher link <directory> <package>"
+  assert_line "Usage: basher link [--no-deps] <directory> <package>"
 }
 
 @test "fails with only one argument" {
   run basher-link invalid
   assert_failure
-  assert_line "Usage: basher link <directory> <package>"
+  assert_line "Usage: basher link [--no-deps] <directory> <package>"
 }
 
 @test "fails with an invalid path" {
@@ -32,15 +32,15 @@ load test_helper
 
   run basher-link package1 invalid
   assert_failure
-  assert_line "Usage: basher link <directory> <package>"
+  assert_line "Usage: basher link [--no-deps] <directory> <package>"
 
   run basher-link package1 namespace1/
   assert_failure
-  assert_line "Usage: basher link <directory> <package>"
+  assert_line "Usage: basher link [--no-deps] <directory> <package>"
 
   run basher-link package1 /package1
   assert_failure
-  assert_line "Usage: basher link <directory> <package>"
+  assert_line "Usage: basher link [--no-deps] <directory> <package>"
 }
 
 @test "links the package to packages under the correct namespace" {
@@ -66,6 +66,17 @@ load test_helper
   assert_line "basher-_link-completions namespace2/package2"
   assert_line "basher-_link-man namespace2/package2"
   assert_line "basher-_deps namespace2/package2"
+}
+
+@test "respects --no-deps option" {
+  mock_command basher-_link-bins
+  mock_command basher-_link-completions
+  mock_command basher-_link-man
+  mock_command basher-_deps
+  mkdir package2
+  run basher-link --no-deps package2 namespace2/package2
+  assert_success
+  refute_line "basher-_deps namespace2/package2"
 }
 
 @test "resolves current directory (dot) path" {


### PR DESCRIPTION
This PR adds a `--no-deps` option to the `link` command, as proposed in my previous PR #43.

I re-used the same code that you used for checking the `--ssh` option on the command line.

Tests are updated.

Maybe still a note to add in the README to tell about this option?

EDIT: force-pushed to remove the #37 commits that you force-erased hahaha