### PR TITLE
Fix resolve_link function for busybox/alpine

### DIFF
--- a/libexec/basher-link
+++ b/libexec/basher-link
@@ -5,7 +5,11 @@
 set -e
 
 resolve_link() {
-  $(type -p realpath readlink | head -n1) -e "$1"
+  if type -p realpath >/dev/null; then
+    realpath "$1"
+  else
+    readlink -f "$1"
+  fi
 }
 
 no_deps="false"

--- a/tests/basher-link.bats
+++ b/tests/basher-link.bats
@@ -3,7 +3,11 @@
 load test_helper
 
 resolve_link() {
-  $(type -p realpath readlink | head -n1) -e "$1"
+  if type -p realpath >/dev/null; then
+    realpath "$1"
+  else
+    readlink -f "$1"
+  fi
 }
 
 @test "without arguments prints usage" {


### PR DESCRIPTION
Fixes #49.

As you said, simple solution. Maybe later we'll use something more portable like bashup/realpaths :slightly_smiling_face: 

Tests remained unchanged.

If you want ever want to update the Travis config to test on different distros, note that you need to 

```
git config --global user.email "you@example.com"
git config --global user.name "Your Name"
```

before running the tests.