### PR TITLE
Fix detect-shell on busybox/alpine

### DIFF
--- a/libexec/basher-init
+++ b/libexec/basher-init
@@ -6,7 +6,7 @@ set -e
 
 shell="$2"
 if [ -z "$shell" ]; then
-  shell="$(ps c -p "$PPID" -o 'ucomm=' 2>/dev/null || true)"
+  shell="$(ps -o comm= -o pid= | grep "$PPID" 2>/dev/null || true)"
   shell="${shell##-}"
   shell="${shell%% *}"
   shell="$(basename "${shell:-$SHELL}")"


### PR DESCRIPTION
Fixes #50.

Change the `ps` command in `basher-init` to be more portable (no `c` or `-p` option on busybox, no `ucomm` column).

We print the PID to grep the the current process' `PPID` variable.

The PID in the output is removed by the `shell="${shell%% *}"` line.