### PR TITLE
Remove dead code from previous basher link command

### DIFF
--- a/tests/basher-outdated.bats
+++ b/tests/basher-outdated.bats
@@ -21,18 +21,6 @@ load test_helper
   assert_output username/outdated
 }
 
-@test "ignores link packages" {
-  mock_clone
-  create_package username/outdated
-  basher-install username/outdated
-  create_exec username/outdated "second"
-  create_link_package skip
-
-  run basher-outdated
-  assert_success
-  assert_output username/outdated
-}
-
 @test "ignore packages checked out with a tag or ref" {
   mock_clone
   create_package username/tagged

--- a/tests/lib/package_helpers.bash
+++ b/tests/lib/package_helpers.bash
@@ -10,13 +10,6 @@ create_package() {
   cd "${BASHER_CWD}"
 }
 
-create_link_package() {
-  local name="$1"
-  mkdir -p "${BASHER_PACKAGES_PATH}/link"
-  mkdir -p "${BASHER_ORIGIN_DIR}/$name"
-  ln -s "${BASHER_ORIGIN_DIR}/$name" "${BASHER_PACKAGES_PATH}/link/$name"
-}
-
 create_file() {
   local package="$1"
   local filename="$2"


### PR DESCRIPTION
Fixes #57.

`basher link` does not link packages in the `link` namespace anymore, so these tests are deprecated.