### PR TITLE
Link to a maintained bats repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ Run `basher update` to update basher.
 ### Installing packages from github.com
 
 ~~~ sh
-$ basher install sstephenson/bats
+$ basher install bats-core/bats
 ~~~
 
-This will install bats from https://github.com/sstephenson/bats and add `bin/bats` to the PATH.
+This will install bats from https://github.com/bats-core/bats and add `bin/bats` to the PATH.
 
 ### Installing packages from other sites
 
@@ -161,7 +161,7 @@ above.
 - [juanibiapina/todo](https://github.com/juanibiapina/todo)
 - [pote/gpm](https://github.com/pote/gpm)
 - [pote/gvp](https://github.com/pote/gvp)
-- [sstephenson/bats](https://github.com/sstephenson/bats)
+- [bats-core/bats](https://github.com/bats-core/bats)
 - [tj/git-extras](https://github.com/tj/git-extras)
 - [jimeh/tmuxifier](https://github.com/jimeh/tmuxifier)
 - [treyhunner/tmuxstart](https://github.com/treyhunner/tmuxstart)
@@ -173,7 +173,7 @@ And many others. If a repo doesn't work, create an issue or a pull request.
 To run the tests, install bats:
 
 ~~~ sh
-$ basher install sstephenson/bats
+$ basher install bats-core/bats
 ~~~
 
 update submodules:


### PR DESCRIPTION
The original `bats` repository is no longer maintained, so a fork has been created to provide a maintained version.