### PR TITLE
Add 0x0 to the package list

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ above.
 
 - [bltavares/kickstart](https://github.com/bltavares/kickstart)
 - [bripkens/dock](https://github.com/bripkens/dock)
+- [Calinou/0x0](https://github.com/Calinou/0x0)
 - [juanibiapina/gg](https://github.com/juanibiapina/gg)
 - [juanibiapina/pg](https://github.com/juanibiapina/pg)
 - [juanibiapina/todo](https://github.com/juanibiapina/todo)


### PR DESCRIPTION
0x0 is a shell wrapper for the file host [0x0.st](https://0x0.st/).

The Working packages list is currently quite short and contains many unmaintained packages. I don't know if this package list is supposed to be added to, if not, let me know :slightly_smiling_face: