### PR TITLE
Fix detect shell test on Git Bash

### DIFF
--- a/libexec/basher-init
+++ b/libexec/basher-init
@@ -6,7 +6,7 @@ set -e
 
 shell="$2"
 if [ -z "$shell" ]; then
-  shell="$(ps -o comm= -o pid= | grep "$PPID" 2>/dev/null || true)"
+  shell="$(ps -o comm= -o pid= 2>/dev/null | grep "$PPID" 2>/dev/null || true)"
   shell="${shell##-}"
   shell="${shell%% *}"
   shell="$(basename "${shell:-$SHELL}")"


### PR DESCRIPTION
The version of the `ps` command that comes with Git Bash for Windows does not support the `-o` flag so running `basher init -` results in the following printed to stderr:

```
ps: unknown option -- o
Try `ps --help' for more information.
```

Redirecting stderr seems to allow it to work appropriately.