### PR TITLE
Remove shell detection in basher init

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,36 +19,20 @@ Even though it is called basher, it also works with zsh and fish.
     $ git clone https://github.com/basherpm/basher.git ~/.basher
     ~~~
 
-2. Add `~/.basher/bin` to `$PATH` for easy access to the basher command-line utility.
+2. Initialize basher in your shell initialization
 
     ~~~ sh
-    $ echo 'export PATH="$HOME/.basher/bin:$PATH"' >> ~/.bash_profile
+    export PATH="$HOME/.basher/bin:$PATH"'
+    eval "$(basher init -)"
     ~~~
 
-    **Ubuntu Desktop note**: Modify your `~/.bashrc` instead of `~/.bash_profile`.
-
-    **Zsh note**: Modify your `~/.zshrc` file instead of `~/.bash_profile`.
-
-    **For Fish**: Add the following to you `~/.config/fish/config.fish`
+    **Fish**: Use the following commands instead:
 
     ~~~ sh
     if test -d ~/.basher
       set basher ~/.basher/bin
     end
     set -gx PATH $basher $PATH
-    ~~~
-
-3. Add `basher init` to your shell to enable basher runtime functions
-
-    ~~~ sh
-    $ echo 'eval "$(basher init -)"' >> ~/.bash_profile
-    ~~~
-
-    _Same as in previous step, use `~/.bashrc` on Ubuntu, `~/.zshrc` for Zsh._
-
-    _For **Fish**, use the following line on your `~/.config/fish/config.fish`._
-
-    ~~~ sh
     status --is-interactive; and . (basher init -|psub)
     ~~~
 
@@ -63,7 +47,7 @@ $ git pull
 
 ## Usage
 
-### Installing packages from github.com
+### Installing packages from Github
 
 ~~~ sh
 $ basher install sstephenson/bats

--- a/libexec/basher-init
+++ b/libexec/basher-init
@@ -6,10 +6,13 @@ set -e
 
 shell="$2"
 if [ -z "$shell" ]; then
-  shell="$(ps -o comm= -o pid= | grep "$PPID" 2>/dev/null || true)"
-  shell="${shell##-}"
-  shell="${shell%% *}"
-  shell="$(basename "${shell:-$SHELL}")"
+  echo "echo 'basher init usage has changed, please specify the name of your shell as an argument:
+
+eval \"\$(basher init - bash)\" # or zsh, fish, sh etc
+
+For more information, check this PR: https://github.com/basherpm/basher/pull/77
+'"
+  exit 1
 fi
 
 print_fish_commands() {

--- a/tests/basher-init.bats
+++ b/tests/basher-init.bats
@@ -2,10 +2,15 @@
 
 load test_helper
 
-@test "detects the shell" {
-  SHELL=/bin/false run basher-init -
-  assert_success
-  assert_line -n 0 'export BASHER_SHELL=bash'
+@test "without enough arguments, prints a useful message" {
+  run basher-init -
+  assert_failure
+  assert_output "echo 'basher init usage has changed, please specify the name of your shell as an argument:
+
+eval \"\$(basher init - bash)\" # or zsh, fish, sh etc
+
+For more information, check this PR: https://github.com/basherpm/basher/pull/77
+'"
 }
 
 @test "exports BASHER_ROOT" {


### PR DESCRIPTION
- less code to maintain
- this code didn't work well in all platforms
- faster shell startup (in my benchmarks it's 6ms faster)

This change is backwards incompatible and will require manual changes to
the startup code.

Replaces https://github.com/basherpm/basher/pull/75