### PR TITLE
Fix: use which instead of type to check for realpath

### DIFF
--- a/libexec/basher-link
+++ b/libexec/basher-link
@@ -5,7 +5,7 @@
 set -e
 
 resolve_link() {
-  if type -p realpath >/dev/null; then
+  if which realpath >/dev/null; then
     realpath "$1"
   else
     readlink -f "$1"


### PR DESCRIPTION
For whatever reason, `type -p realpath` returns empty on macOS even though `realpath` exists, and so it defaults to using `readlink -f` which does not work on macOS.

Using `which realpath` seems to work better.