### PR TITLE
modify: Don't use "readlink -f" in "resolve_link"

### DIFF
--- a/libexec/basher-link
+++ b/libexec/basher-link
@@ -8,7 +8,28 @@ resolve_link() {
   if type -p realpath >/dev/null; then
     realpath "$1"
   else
-    readlink -f "$1"
+    local path="$1"
+
+    if [[ "${path%/*}" = "$path" ]]; then
+      if [[ -d "$path" ]];then
+        echo "$(cd "$path"; pwd)"
+      else
+        echo "$(pwd)/$path"
+      fi
+      return
+    fi
+
+    local cwd="$(pwd)"
+    while [[ -L "$path" ]]; do
+      cd "${path%/*}"
+      local name="${path##*/}"
+      path="$(readlink "$name" || true)"
+    done
+
+    local parent="$(cd "${path%/*}"; pwd)"
+    echo "$parent/${path##*/}"
+
+    cd "$cwd"
   fi
 }
 

--- a/tests/basher-link.bats
+++ b/tests/basher-link.bats
@@ -6,7 +6,28 @@ resolve_link() {
   if type -p realpath >/dev/null; then
     realpath "$1"
   else
-    readlink -f "$1"
+    local path="$1"
+
+    if [[ "${path%/*}" = "$path" ]]; then
+      if [[ -d "$path" ]];then
+        echo "$(cd "$path"; pwd)"
+      else
+        echo "$(pwd)/$path"
+      fi
+      return
+    fi
+
+    local cwd="$(pwd)"
+    while [[ -L "$path" ]]; do
+      cd "${path%/*}"
+      local name="${path##*/}"
+      path="$(readlink "$name" || true)"
+    done
+
+    local parent="$(cd "${path%/*}"; pwd)"
+    echo "$parent/${path##*/}"
+
+    cd "$cwd"
   fi
 }
 


### PR DESCRIPTION
Because macOS doesn't have GNU readlink nor "realpath" by default.

Though this code somehow works, it might look a bit ugly.  
How do you think of this?

I found this duplicates with #60 . But it is still left open.