### PR TITLE
Allows custom folder name

### DIFF
--- a/libexec/basher-_clone
+++ b/libexec/basher-_clone
@@ -2,11 +2,11 @@
 #
 # Summary: Clones a package from a site, but doesn't install it
 #
-# Usage: basher _clone <use_ssh> <site> <package> [<ref>]
+# Usage: basher _clone <use_ssh> <site> <package> [<ref>] [folder]
 
 set -e
 
-if [ "$#" -ne 3 -a "$#" -ne 4 ]; then
+if [ "$#" -lt 3 -a "$#" -gt 5 ]; then
   basher-help _clone
   exit 1
 fi
@@ -15,6 +15,7 @@ use_ssh="$1"
 site="$2"
 package="$3"
 ref="$4"
+folder="$5"
 
 if [ -z "$use_ssh" ]; then
   basher-help _clone
@@ -49,7 +50,11 @@ if [ -z "$name" ]; then
   exit 1
 fi
 
-if [ -e "$BASHER_PACKAGES_PATH/$package" ]; then
+if [ -z "$folder" ]; then
+  folder="$package"
+fi
+
+if [ -e "$BASHER_PACKAGES_PATH/$folder" ]; then
   echo "Package '$package' is already present"
   exit 0
 fi
@@ -66,4 +71,4 @@ else
   URI="https://${site}/$package.git"
 fi
 
-git clone ${DEPTH_OPTION} ${BRANCH_OPTION} --recursive "$URI" "${BASHER_PACKAGES_PATH}/$package"
+git clone ${DEPTH_OPTION} ${BRANCH_OPTION} --recursive "$URI" "${BASHER_PACKAGES_PATH}/$folder"

--- a/libexec/basher-install
+++ b/libexec/basher-install
@@ -2,7 +2,7 @@
 #
 # Summary: Installs a package from github (or a custom site)
 #
-# Usage: basher install [--ssh] [site]/<package>[@ref]
+# Usage: basher install [--ssh] [site]/<package>[@ref] [folder]
 
 set -e
 
@@ -15,7 +15,7 @@ case $1 in
   ;;
 esac
 
-if [ "$#" -ne 1 ]; then
+if [ "$#" -lt 1 -o "$#" -gt 2 ]; then
   basher-help install
   exit 1
 fi
@@ -26,6 +26,17 @@ if [[ "$1" = */*/* ]]; then
 else
   package="$1"
   site="github.com"
+fi
+
+# defaults to package's name, but allows custom folder name
+folder="$package"
+if [ -n "$2" ]; then
+  if [[ "$2" = */* ]]; then
+    basher-help install
+    echo "Optional argunment [folder] cannot be nested."
+    exit 1
+  fi
+  folder="${user}/$2"
 fi
 
 if [ -z "$package" ]; then
@@ -51,12 +62,8 @@ else
   ref=""
 fi
 
-if [ -z "$ref" ]; then
-  basher-_clone "$use_ssh" "$site" "$package"
-else
-  basher-_clone "$use_ssh" "$site" "$package" "$ref"
-fi
-basher-_deps "$package"
-basher-_link-bins "$package"
-basher-_link-man "$package"
-basher-_link-completions "$package"
+basher-_clone "$use_ssh" "$site" "$package" "$ref" "$folder"
+basher-_deps "$folder"
+basher-_link-bins "$folder"
+basher-_link-man "$folder"
+basher-_link-completions "$folder"

--- a/libexec/basher-list
+++ b/libexec/basher-list
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 #
 # Summary: List installed packages
-# Usage: basher list
+# Usage: basher list [-v]
 
 set -e
+
+case $1 in
+  -v)
+    verbose="true"
+    shift
+  ;;
+esac
 
 if [ "$#" -gt 0 ]; then
   basher-help list
@@ -17,5 +24,9 @@ do
   username="$(dirname "$package_path")"
   username="${username##*/}"
   package="${package_path##*/}"
-  echo "$username/$package"
+  if [ -z "$verbose" ]; then
+    echo "$username/$package"
+  else
+    printf "%-30s %-30s\n" "$username/$package" "($(git --git-dir=${BASHER_PACKAGES_PATH}/$username/$package/.git config --get remote.origin.url))"
+  fi
 done


### PR DESCRIPTION
This PR adds the ability to clone into a named folder (same as the normal git clone command where you can clone to any folder), with the exception that it's to rename the result folder.

**Use case:** I uses lots of gist to host the script that I used (and easy to share). My `basher list` looks something like:
```sh
dylanaraps/neofetch
pepa65/tldr-bash-client
simonthum/git-sync
so-fancy/diff-so-fancy
soraxas/0ef22338ad01e470cd62595d2e5623dd
soraxas/4c54c944714412baeb1b773ff10d7261
soraxas/507cbff5fab0a10f71cdc4b9179e3e36
soraxas/711591894b79be8916ef85307f1a3552
soraxas/72ed82761fc7435e8d2bf4d2043d641f
soraxas/735c512a785b8278b9faffdbb303b37b
soraxas/ab594b0cf5c49b4e36c04249f0b7c2f7
soraxas/dot-reminder
soraxas/works
```

With this PR, I can install package with
```sh
basher install gist.github.com/soraxas/735c512a785b8278b9faffdbb303b37b git-utils
```
and it will clone into `celler/soraxas/git-utils`. The result is:
```sh
dylanaraps/neofetch
pepa65/tldr-bash-client
simonthum/git-sync
so-fancy/diff-so-fancy
soraxas/close-gnome-terminal
soraxas/dot-reminder
soraxas/easy-extraction
soraxas/gist-add-x-bit
soraxas/git-utils
soraxas/open-rev-ports
soraxas/parse-assh
soraxas/pdfcrop
soraxas/works
```

In addition, to enhance the `basher list` functinoality, it now has a verbose flag `-v` where will you run
```sh
basher list -v
```
it will displays the upstream URL (also useful to showing hostname other than github.com), like so:
```sh
dylanaraps/neofetch            (https://github.com/dylanaraps/neofetch.git)
pepa65/tldr-bash-client        (https://github.com/pepa65/tldr-bash-client.git)
simonthum/git-sync             (https://github.com/simonthum/git-sync.git)
so-fancy/diff-so-fancy         (https://github.com/so-fancy/diff-so-fancy.git)
soraxas/close-gnome-terminal   (https://gist.github.com/soraxas/711591894b79be8916ef85307f1a3552.git)
soraxas/dot-reminder           (https://github.com/soraxas/dot-reminder.git)
soraxas/easy-extraction        (https://gist.github.com/soraxas/ab594b0cf5c49b4e36c04249f0b7c2f7.git)
soraxas/gist-add-x-bit         (https://gist.github.com/soraxas/507cbff5fab0a10f71cdc4b9179e3e36.git)
soraxas/git-utils              (https://gist.github.com/soraxas/735c512a785b8278b9faffdbb303b37b.git)
soraxas/open-rev-ports         (https://gist.github.com/soraxas/0ef22338ad01e470cd62595d2e5623dd.git)
soraxas/parse-assh             (https://gist.github.com/soraxas/72ed82761fc7435e8d2bf4d2043d641f.git)
soraxas/pdfcrop                (https://gist.github.com/soraxas/4c54c944714412baeb1b773ff10d7261.git)
soraxas/works                  (https://gist.github.com/soraxas/4c54c944714412baeb1b773ff10d7261.git)
```