### PR TITLE
fix #28

### DIFF
--- a/libexec/basher-_deps
+++ b/libexec/basher-_deps
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Usage: basher _deps <package>
+# Usage: basher _deps <package> [--get]
 # Summary: Globally installs package runtime dependencies
 #
 # Installs the package dependencies, specified with the
@@ -9,6 +9,13 @@
 # Example: DEPS=username/repo1:otheruser/repo2
 
 set -e
+
+case $1 in
+  --get)
+    get_deps="true"
+    shift
+  ;;
+esac
 
 if [ "$#" -ne 1 ]; then
   basher-help _deps
@@ -28,5 +35,9 @@ IFS=: read -a deps <<< "$DEPS"
 
 for dep in "${deps[@]}"
 do
-  basher-install "$dep"
+  if [ -z "$get_deps" ]
+    basher-install "$dep"
+  else
+    echo "$dep"
+  fi
 done

--- a/libexec/basher-upgrade
+++ b/libexec/basher-upgrade
@@ -34,4 +34,28 @@ if [ -z "$name" ]; then
 fi
 
 cd "${BASHER_PACKAGES_PATH}/$package"
+git remote update > /dev/null 2>&1
+if git symbolic-ref --short -q HEAD > /dev/null; then
+    if [ "$(git rev-list --count HEAD...HEAD@{upstream})" -eq 0 ]; then
+      # Exit when no need to upgrades. This also helps to avoid inf recursion even if
+      # some package happened to set itself to be its own dependencies.
+      exit
+    fi
+fi
+
+# unlink everything first
+basher-_unlink-man "$package"
+basher-_unlink-bins "$package"
+basher-_unlink-completions "$package"
+# upgrade the package
+cd "${BASHER_PACKAGES_PATH}/$package"
 git pull
+# relink the package components
+basher-_link-bins "$package"
+basher-_link-man "$package"
+basher-_link-completions "$package"
+# upgrade any dependencies it needs
+for dep in $(basher-_deps --get "$package")
+do
+  basher-upgrade "$dep"
+done


### PR DESCRIPTION
This PR adds:
- perform unlink/relink when upgrading a package
- It also performs upgrade on its dependencies.
- Exit upgrade gracefully if it's not upgradable (using same logic as outdated) so that unlinking/relinking won't be performed.

This addresses #28