### PR TITLE
prevent package conflicts when linking and uninstalling

### DIFF
--- a/libexec/basher-_clone
+++ b/libexec/basher-_clone
@@ -51,7 +51,7 @@ fi
 
 if [ -e "$BASHER_PACKAGES_PATH/$package" ]; then
   echo "Package '$package' is already present"
-  exit 0
+  exit 1
 fi
 
 if [ "$BASHER_FULL_CLONE" = "true" ]; then

--- a/libexec/basher-_link-bins
+++ b/libexec/basher-_link-bins
@@ -27,6 +27,6 @@ do
     name="${name%%.*}"
   fi
   mkdir -p "$BASHER_INSTALL_BIN"
-  ln -sf "$BASHER_PACKAGES_PATH/$package/$bin" "$BASHER_INSTALL_BIN/${name}"
+  ln -s "$BASHER_PACKAGES_PATH/$package/$bin" "$BASHER_INSTALL_BIN/${name}"
   chmod +x "$BASHER_INSTALL_BIN/${name}"
 done

--- a/libexec/basher-_link-completions
+++ b/libexec/basher-_link-completions
@@ -15,7 +15,7 @@ IFS=: read -a zsh_completions <<< "$ZSH_COMPLETIONS"
 for completion in "${bash_completions[@]}"
 do
   mkdir -p "$BASHER_PREFIX/completions/bash"
-  ln -sf "$BASHER_PACKAGES_PATH/$package/$completion" "$BASHER_PREFIX/completions/bash/${completion##*/}"
+  ln -s "$BASHER_PACKAGES_PATH/$package/$completion" "$BASHER_PREFIX/completions/bash/${completion##*/}"
 done
 
 for completion in "${zsh_completions[@]}"
@@ -23,9 +23,9 @@ do
   target="$BASHER_PACKAGES_PATH/$package/$completion"
   if grep -q "#compdef" "$target"; then
     mkdir -p "$BASHER_PREFIX/completions/zsh/compsys"
-    ln -sf "$target" "$BASHER_PREFIX/completions/zsh/compsys/${completion##*/}"
+    ln -s "$target" "$BASHER_PREFIX/completions/zsh/compsys/${completion##*/}"
   else
     mkdir -p "$BASHER_PREFIX/completions/zsh/compctl"
-    ln -sf "$target" "$BASHER_PREFIX/completions/zsh/compctl/${completion##*/}"
+    ln -s "$target" "$BASHER_PREFIX/completions/zsh/compctl/${completion##*/}"
   fi
 done

--- a/libexec/basher-_link-man
+++ b/libexec/basher-_link-man
@@ -16,6 +16,6 @@ do
   if [[ "$file" =~ $pattern ]]; then
     n="${BASH_REMATCH[1]}"
     mkdir -p "${BASHER_INSTALL_MAN}/man${n}"
-    ln -sf "$BASHER_PACKAGES_PATH/$package/man/$file" "$BASHER_INSTALL_MAN/man${n}/${file}"
+    ln -s "$BASHER_PACKAGES_PATH/$package/man/$file" "$BASHER_INSTALL_MAN/man${n}/${file}"
   fi
 done

--- a/libexec/basher-_unlink-bins
+++ b/libexec/basher-_unlink-bins
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+resolve_link() {
+  if type -p realpath >/dev/null; then
+    realpath "$1"
+  else
+    readlink -f "$1"
+  fi
+}
+
+remove_linked() {
+  if [[ "$(resolve_link $1)" = "$2/"* ]]; then
+    rm -f "$1"
+  fi
+}
+
 package="$1"
 
 if [ -e "$BASHER_PACKAGES_PATH/$package/package.sh" ]; then
@@ -24,5 +38,6 @@ do
   if ${REMOVE_EXTENSION:-false}; then
     name="${name%%.*}"
   fi
-  rm -f "$BASHER_INSTALL_BIN/${name}"
+  # only deletes if it actually owned (linked) by this package
+  remove_linked "$BASHER_INSTALL_BIN/${name}" "$BASHER_PACKAGES_PATH/$package"
 done

--- a/libexec/basher-_unlink-completions
+++ b/libexec/basher-_unlink-completions
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+resolve_link() {
+  if type -p realpath >/dev/null; then
+    realpath "$1"
+  else
+    readlink -f "$1"
+  fi
+}
+
+remove_linked() {
+  if [[ "$(resolve_link $1)" = "$2/"* ]]; then
+    rm -f "$1"
+  fi
+}
+
 package="$1"
 
 if [ ! -e "$BASHER_PACKAGES_PATH/$package/package.sh" ]; then
@@ -21,8 +35,8 @@ for completion in "${zsh_completions[@]}"
 do
   target="$BASHER_PACKAGES_PATH/$package/$completion"
   if grep -q "#compdef" "$target"; then
-    rm -f "$BASHER_PREFIX/completions/zsh/compsys/${completion##*/}"
+    remove_linked "$BASHER_PREFIX/completions/zsh/compsys/${completion##*/}" "$BASHER_PACKAGES_PATH/$package"
   else
-    rm -f "$BASHER_PREFIX/completions/zsh/compctl/${completion##*/}"
+    remove_linked "$BASHER_PREFIX/completions/zsh/compctl/${completion##*/}" "$BASHER_PACKAGES_PATH/$package"
   fi
 done

--- a/libexec/basher-_unlink-man
+++ b/libexec/basher-_unlink-man
@@ -2,6 +2,20 @@
 
 set -e
 
+resolve_link() {
+  if type -p realpath >/dev/null; then
+    realpath "$1"
+  else
+    readlink -f "$1"
+  fi
+}
+
+remove_linked() {
+  if [[ "$(resolve_link $1)" = "$2/"* ]]; then
+    rm -f "$1"
+  fi
+}
+
 package="$1"
 
 shopt -s nullglob
@@ -15,6 +29,6 @@ for file in "${files[@]}"
 do
   if [[ "$file" =~ $pattern ]]; then
     n="${BASH_REMATCH[1]}"
-    rm -f "$BASHER_INSTALL_MAN/man${n}/${file}"
+    remove_linked "$BASHER_INSTALL_MAN/man${n}/${file}" "$BASHER_PACKAGES_PATH/$package"
   fi
 done


### PR DESCRIPTION
This PR is aimed to prevent packages conflicts; namely, when two different packages has identical names for binaries/man/completions.

This means avoid the `-f` flag in `ln` to NOT overwrite when file exists (a user should resolve packages conflict on their own), and when uninstalling a package it will checks that: if the link to be removed is indeed from the package that we are uninstalling (by resolving the link).