### PR TITLE
add install/uninstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Even though it is called basher, it also works with zsh and fish.
     status --is-interactive; and . (basher init - fish|psub)
     ~~~
 
-or in 1 line, automatically
+or in 1 line, automatically (this will install basher and add it to your .bashrc/.zshrc file - in a way that can automatically be uninstalled later)):
 
 	curl -s https://raw.githubusercontent.com/basherpm/basher/master/install.sh | bash
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Even though it is called basher, it also works with zsh and fish.
     status --is-interactive; and . (basher init - fish|psub)
     ~~~
 
+or in 1 line, automatically
+
+	curl -s https://raw.githubusercontent.com/basherpm/basher/master/install.sh | bash
+
 ## Updating
 
 Go to the directory where you cloned basher and pull the latest changes:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+die() {
+  echo "!! $1 " >&2
+  echo "!! -----------------------------" >&2
+  exit 1
+}
+
+## stop if basher is already installed
+[[ -d "$HOME/.basher" ]] && die "basher is already installed on [$HOME/.basher]"
+
+## stop if git is not installed
+git version >/dev/null 2>&1 || die "git is not installed on this machine"
+
+## install the scripts on ~/.basher
+echo ". download basher code to ~/.basher"
+git clone https://github.com/basherpm/basher.git ~/.basher 2> /dev/null
+
+## now check what shell is running
+shell_type=$(basename "$SHELL")
+echo ". detected shell type: $shell_type"
+case "$shell_type" in
+bash)  startup_type="simple" ; startup_script="$HOME/.bashrc" ;;
+zsh)   startup_type="simple" ; startup_script="$HOME/.zshrc"  ;;
+sh)    startup_type="simple" ; startup_script="$HOME/.profile";;
+fish)  startup_type="fish"   ; startup_script="$HOME/.config/fish/config.fish"  ;;
+*)     startup_type="?"      ; startup_script="" ;   ;;
+esac
+
+## startup script should exist already
+[[ -n "$startup_script" && ! -f "$startup_script" ]] && die "startup script [$startup_script] does not exist"
+
+## basher_keyword will allow us to remove the lines upon uninstall
+basher_keyword="basher5ea843"
+
+## now add the basher initialisation lines to the user's startup script
+echo ". add basher initialisation to [$startup_script]"
+if [[ "$startup_type" == "simple" ]]; then
+  (
+    echo "export PATH=\"\$HOME/.basher/bin:\$PATH\"   ##$basher_keyword"
+    # shellcheck disable=SC2086
+    echo "eval \"\$(basher init - $shell_type)\"             ##$basher_keyword"
+  ) >>"$startup_script"
+elif [[ "$startup_type" == "fish" ]]; then
+  (
+    echo "if test -d ~/.basher          ##$basher_keyword"
+    echo "  set basher ~/.basher/bin    ##$basher_keyword"
+    echo "end                           ##$basher_keyword"
+    # shellcheck disable=SC2154
+    echo "set -gx PATH \$basher \$PATH    ##$basher_keyword"
+    echo "status --is-interactive; and . (basher init - $shell_type | psub)    ##$basher_keyword"
+  ) >>"$startup_script"
+else
+  die "unknown shell [$shell_type] - can't initialise"
+fi
+
+## script is finished
+echo "basher is installed - open a new terminal window to start using it"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+die() {
+  echo "!! $1 " >&2
+  echo "!! -----------------------------" >&2
+  exit 1
+}
+
+## stop if basher is not installed
+[[ ! -d "$HOME/.basher" ]] && die "basher doesn't seem to be installed on [$HOME/.basher]"
+echo ". remove basher code and installed packages"
+basher list
+sleep 2
+rm -fr "$HOME/.basher"
+
+## now check what shell is running
+shell_type=$(basename "$SHELL")
+case "$shell_type" in
+bash)  startup_type="simple" ; startup_script="$HOME/.bashrc" ;;
+zsh)   startup_type="simple" ; startup_script="$HOME/.zshrc"  ;;
+sh)    startup_type="simple" ; startup_script="$HOME/.profile";;
+fish)  startup_type="fish"   ; startup_script="$HOME/.config/fish/config.fish"  ;;
+*)     startup_type="?"      ; startup_script="" ;   ;;
+esac
+
+## startup script should exist already
+[[ -n "$startup_script" && ! -f "$startup_script" ]] && die "startup script [$startup_script] does not exist"
+
+## basher_keyword will allow us to remove the lines upon uninstall
+basher_keyword="basher5ea843"
+
+echo ". following basher folders are in your path:"
+echo $PATH | tr ':' "\n" | grep basher
+
+if grep -q "$basher_keyword" "$startup_script" ; then
+  echo ". remove basher from startup script [$startup_script]"
+  sleep 1
+  temp_file="$startup_script.temp"
+  cp "$startup_script" "$temp_file"
+  < "$temp_file" grep -v "$basher_keyword" > "$startup_script"
+  rm "$temp_file"
+elif grep -q basher "$startup_script" ; then
+    grep basher "$startup_script"
+    die "Can't auto-remove the lines from $(basename $startup_script) - please do so manually "
+else
+    die "Can't find initialisation commands for basher"
+fi
+
+## script is finished
+echo "basher is uninstalled"


### PR DESCRIPTION
this PR creates an 'install.sh' script that can be used in a on-line installation step:
curl -s https://raw.githubusercontent.com/basherpm/basher/master/install.sh | bash

to test it now (before merge):
     `curl -s https://raw.githubusercontent.com/pforret/basher/master/install.sh | bash`
or
     `curl -s https://raw.githubusercontent.com/pforret/basher/master/install.sh | zsh`

it should work for bash/zsh/sh/fish

there is also an 'uninstall.sh' script that removes basher and basher-related lines in `~/.bashrc/` , `~/.zshrc` etc
