### PR TITLE
Support specifying multiple packages to install or uninstall

### DIFF
--- a/libexec/basher-install
+++ b/libexec/basher-install
@@ -15,48 +15,50 @@ case $1 in
   ;;
 esac
 
-if [ "$#" -ne 1 ]; then
+if [ "$#" -lt 1 ]; then
   basher-help install
   exit 1
 fi
 
-if [[ "$1" = */*/* ]]; then
-  IFS=/ read -r site user name <<< "$1"
-  package="${user}/${name}"
-else
-  package="$1"
-  site="github.com"
-fi
+for pkgSpec in "$@"; do
+  if [[ "$pkgSpec" = */*/* ]]; then
+    IFS=/ read -r site user name <<< "$pkgSpec"
+    package="${user}/${name}"
+  else
+    package="$pkgSpec"
+    site="github.com"
+  fi
 
-if [ -z "$package" ]; then
-  basher-help install
-  exit 1
-fi
+  if [ -z "$package" ]; then
+    basher-help install
+    exit 1
+  fi
 
-IFS=/ read -r user name <<< "$package"
+  IFS=/ read -r user name <<< "$package"
 
-if [ -z "$user" ]; then
-  basher-help install
-  exit 1
-fi
+  if [ -z "$user" ]; then
+    basher-help install
+    exit 1
+  fi
 
-if [ -z "$name" ]; then
-  basher-help install
-  exit 1
-fi
+  if [ -z "$name" ]; then
+    basher-help install
+    exit 1
+  fi
 
-if [[ "$package" = */*@* ]]; then
-  IFS=@ read -r package ref <<< "$package"
-else
-  ref=""
-fi
+  if [[ "$package" = */*@* ]]; then
+    IFS=@ read -r package ref <<< "$package"
+  else
+    ref=""
+  fi
 
-if [ -z "$ref" ]; then
-  basher-_clone "$use_ssh" "$site" "$package"
-else
-  basher-_clone "$use_ssh" "$site" "$package" "$ref"
-fi
-basher-_deps "$package"
-basher-_link-bins "$package"
-basher-_link-man "$package"
-basher-_link-completions "$package"
+  if [ -z "$ref" ]; then
+    basher-_clone "$use_ssh" "$site" "$package"
+  else
+    basher-_clone "$use_ssh" "$site" "$package" "$ref"
+  fi
+  basher-_deps "$package"
+  basher-_link-bins "$package"
+  basher-_link-man "$package"
+  basher-_link-completions "$package"
+done

--- a/libexec/basher-uninstall
+++ b/libexec/basher-uninstall
@@ -4,7 +4,7 @@
 
 set -e
 
-if [ "$#" -ne 1 ]; then
+if [ "$#" -lt 1 ]; then
   basher-help uninstall
   exit 1
 fi
@@ -14,34 +14,34 @@ if [ "$1" == "--complete" ]; then
   exec basher-list
 fi
 
-package="$1"
+for package in "$@"; do
+  if [ -z "$package" ]; then
+    basher-help uninstall
+    exit 1
+  fi
 
-if [ -z "$package" ]; then
-  basher-help uninstall
-  exit 1
-fi
+  IFS=/ read -r user name <<< "$package"
 
-IFS=/ read -r user name <<< "$package"
+  if [ -z "$user" ]; then
+    basher-help uninstall
+    exit 1
+  fi
 
-if [ -z "$user" ]; then
-  basher-help uninstall
-  exit 1
-fi
+  if [ -z "$name" ]; then
+    basher-help uninstall
+    exit 1
+  fi
 
-if [ -z "$name" ]; then
-  basher-help uninstall
-  exit 1
-fi
+  shopt -s nullglob
 
-shopt -s nullglob
+  if [ ! -d "$BASHER_PACKAGES_PATH/$package" ]; then
+    echo "Package '$package' is not installed"
+    exit 1
+  fi
 
-if [ ! -d "$BASHER_PACKAGES_PATH/$package" ]; then
-  echo "Package '$package' is not installed"
-  exit 1
-fi
+  basher-_unlink-man "$package"
+  basher-_unlink-bins "$package"
+  basher-_unlink-completions "$package"
 
-basher-_unlink-man "$package"
-basher-_unlink-bins "$package"
-basher-_unlink-completions "$package"
-
-rm -rf "${BASHER_PACKAGES_PATH}/$package"
+  rm -rf "${BASHER_PACKAGES_PATH:?}/$package"
+done

--- a/tests/basher-install.bats
+++ b/tests/basher-install.bats
@@ -14,12 +14,6 @@ load test_helper
   assert_line "Usage: basher install [--ssh] [site]/<package>[@ref]"
 }
 
-@test "too many arguments prints usage" {
-  run basher-install a/b wrong
-  assert_failure
-  assert_line "Usage: basher install [--ssh] [site]/<package>[@ref]"
-}
-
 @test "executes install steps in right order" {
   mock_command basher-_clone
   mock_command basher-_deps

--- a/tests/basher-uninstall.bats
+++ b/tests/basher-uninstall.bats
@@ -14,12 +14,6 @@ load test_helper
   assert_line "Usage: basher uninstall <package>"
 }
 
-@test "with too many arguments, prints usage" {
-  run basher-uninstall a/b lol
-  assert_failure
-  assert_line "Usage: basher uninstall <package>"
-}
-
 @test "fails if package is not installed" {
   run basher-uninstall user/lol
   assert_failure


### PR DESCRIPTION
Rather than error if more than one package is specified when using `basher install` or `basher uninstall`, it iterates through each of them, one after another until all are installed. If any installation or uninstallation errors, execution stops with any usual error message. Ensured all tests pass locally

<details>
<summary>Test Results</summary>

```bash
basher on  feat/install-multiple-packages via 🐏 8GiB/16GiB 
➤ make test
bats tests
1..118
ok 1 default BASHER_ROOT
ok 2 inherited BASHER_ROOT
ok 3 default BASHER_PREFIX
ok 4 inherited BASHER_PREFIX
ok 5 BASHER_PREFIX based on BASHER_ROOT
ok 6 inherited BASHER_PACKAGES_PATH
ok 7 BASHER_PACKAGES_PATH based on BASHER_PREFIX
ok 8 default BASHER_INSTALL_BIN
ok 9 inherited BASHER_INSTALL_BIN
ok 10 BASHER_INSTALL_BIN based on BASHER_PREFIX
ok 11 default BASHER_INSTALL_MAN
ok 12 inherited BASHER_INSTALL_MAN
ok 13 BASHER_INSTALL_MAN based on BASHER_PREFIX
ok 14 without arguments prints usage
ok 15 invalid package prints usage
ok 16 too many arguments prints usage
ok 17 install a specific version
ok 18 does nothing if package is already present
ok 19 using a different site
ok 20 without setting BASHER_FULL_CLONE, clones a package with depth option
ok 21 setting BASHER_FULL_CLONE to true, clones a package without depth option
ok 22 setting BASHER_FULL_CLONE to false, clones a package with depth option
ok 23 using ssh protocol
ok 24 without arguments prints usage
ok 25 lists commands
ok 26 does not list hidden commands
ok 27 command with no completion support
ok 28 command with completion support
ok 29 without arguments, prints usage
ok 30 without dependencies, does nothing
ok 31 installs dependencies
ok 32 without args shows summary of common commands
ok 33 invalid command
ok 34 shows help for a specific command
ok 35 replaces missing extended help with summary text
ok 36 extracts only usage
ok 37 multiline usage section
ok 38 multiline extended help section
ok 39 without enough arguments, prints a useful message
ok 40 exports BASHER_ROOT
ok 41 exports BASHER_PREFIX
ok 42 exports BASHER_PACKAGES_PATH
ok 43 adds cellar/bin to path
ok 44 setup include function if it exists
ok 45 doesn't setup include function if it doesn't exist
ok 46 setup basher completions if available
ok 47 does not setup basher completions if not available
ok 48 setup package completions (bash)
ok 49 setup package completions (zsh)
ok 50 is sh-compatible
ok 51 without arguments prints usage
ok 52 incorrect argument prints usage
ok 53 executes install steps in right order
ok 54 with site, overwrites site
ok 55 without site, uses github as default site
ok 56 using ssh protocol
ok 57 installs with custom version
ok 58 empty version is ignored
ok 59 doesn't fail
ok 60 without arguments prints usage
ok 61 fails with only one argument
ok 62 fails with an invalid path
ok 63 fails with a file path instead of a directory path
ok 64 fails with an invalid package name
ok 65 links the package to packages under the correct namespace
ok 66 calls link-bins, link-completions, link-man and deps
ok 67 respects --no-deps option
ok 68 resolves current directory (dot) path
ok 69 resolves parent directory (dotdot) path
ok 70 resolves arbitrary complex relative path
ok 71 links each file on the BINS config on package.sh to the install bin
ok 72 links each file inside bin folder to install bin
ok 73 links each exec file in package root to install bin
ok 74 doesn't link root bins if there is a bin folder
ok 75 doesn't link root bins or files in bin folder if there is a BINS config on package.sh
ok 76 does not fail if there are no binaries
ok 77 remove extension if REMOVE_EXTENSION is true
ok 78 does not remove extension if REMOVE_EXTENSION is false
ok 79 does not symlink package itself as bin when linked with basher link
ok 80 links bash completions to prefix/completions
ok 81 links zsh compsys completions to prefix/completions
ok 82 links zsh compctl completions to prefix/completions
ok 83 does not fail if package doesn't have any completions
ok 84 links each man page to install-man under correct subdirectory
ok 85 with arguments shows usage
ok 86 list installed packages
ok 87 displays nothing if there are no packages
ok 88 displays outdated packages
ok 89 ignore packages checked out with a tag or ref
ok 90 without arguments, prints usage
ok 91 outputs the package path
ok 92 without arguments prints usage
ok 93 with invalid arguments, prints usage
ok 94 fails if package is not installed
ok 95 removes package directory
ok 96 removes binaries
ok 97 does not remove other package directories and binaries
ok 98 removes each binary in BINS config from the install bin
ok 99 removes each binary from the install bin
ok 100 removes root binaries from the install bin
ok 101 doesn't remove root binaries if there is a bin folder
ok 102 doesn't remote root bins or files in bin folder if there is a BINS config on package.sh
ok 103 does not fail if there are no binaries
ok 104 removes binary when REMOVE_EXTENSION is true
ok 105 removes binary when REMOVE_EXTENSION is false
ok 106 unlinks bash completions from prefix/completions
ok 107 unlinks zsh compsys completions from prefix/completions
ok 108 unlinks zsh compctl completions from prefix/completions
ok 109 removes each man page from the install-man
ok 110 without arguments shows usage
ok 111 with invalid argument, shows usage
ok 112 with too many arguments, shows usage
ok 113 upgrades a package to the latest version
ok 114 without arguments, prints an error
ok 115 with one argument, prints an error
ok 116 when package is not installed, prints an error
ok 117 when file doesn't exist, prints an error
ok 118 sources a file into the current shell
```
</details>

Closes #96 