### PR TITLE
Improve code quality

### DIFF
--- a/libexec/basher
+++ b/libexec/basher
@@ -9,7 +9,7 @@ resolve_link() {
 }
 
 abs_dirname() {
-  local cwd="$(pwd)"
+  local cwd="$PWD"
   local path="$1"
 
   while [ -n "$path" ]; do

--- a/libexec/basher-_clone
+++ b/libexec/basher-_clone
@@ -6,7 +6,7 @@
 
 set -e
 
-if [ "$#" -ne 3 -a "$#" -ne 4 ]; then
+if [ "$#" -ne 3 ] && [ "$#" -ne 4 ]; then
   basher-help _clone
   exit 1
 fi
@@ -66,4 +66,5 @@ else
   URI="https://${site}/$package.git"
 fi
 
+# shellcheck disable=SC2086
 git clone ${DEPTH_OPTION} ${BRANCH_OPTION} --recursive "$URI" "${BASHER_PACKAGES_PATH}/$package"

--- a/libexec/basher-_commands
+++ b/libexec/basher-_commands
@@ -23,7 +23,7 @@ shopt -s nullglob
     for command in "${path}/$package-"*; do
       command="${command##*$package-}"
       if [[ ! "$command" == _* ]]; then
-        echo ${command}
+        echo "${command}"
       fi
     done
   done

--- a/libexec/basher-_deps
+++ b/libexec/basher-_deps
@@ -24,7 +24,7 @@ fi
 shopt -s nullglob
 
 source "$BASHER_PACKAGES_PATH/$package/package.sh"
-IFS=: read -a deps <<< "$DEPS"
+IFS=: read -ra deps <<< "$DEPS"
 
 for dep in "${deps[@]}"
 do

--- a/libexec/basher-_link-bins
+++ b/libexec/basher-_link-bins
@@ -6,12 +6,12 @@ shopt -s nullglob
 
 if [ -e "$BASHER_PACKAGES_PATH/$package/package.sh" ]; then
   source "$BASHER_PACKAGES_PATH/$package/package.sh"
-  IFS=: read -a bins <<< "$BINS"
+  IFS=: read -ra bins <<< "$BINS"
 fi
 
 if [ -z "$bins" ]; then
   if [ -e "$BASHER_PACKAGES_PATH/$package/bin" ]; then
-    bins=($BASHER_PACKAGES_PATH/$package/bin/*)
+    bins=("$BASHER_PACKAGES_PATH/$package"/bin/*)
     bins=("${bins[@]##*/}")
     bins=("${bins[@]/#/bin/}")
   else

--- a/libexec/basher-_link-completions
+++ b/libexec/basher-_link-completions
@@ -9,8 +9,8 @@ fi
 shopt -s nullglob
 
 source "$BASHER_PACKAGES_PATH/$package/package.sh" # TODO: make this secure?
-IFS=: read -a bash_completions <<< "$BASH_COMPLETIONS"
-IFS=: read -a zsh_completions <<< "$ZSH_COMPLETIONS"
+IFS=: read -ra bash_completions <<< "$BASH_COMPLETIONS"
+IFS=: read -ra zsh_completions <<< "$ZSH_COMPLETIONS"
 
 for completion in "${bash_completions[@]}"
 do

--- a/libexec/basher-_link-man
+++ b/libexec/basher-_link-man
@@ -6,7 +6,7 @@ package="$1"
 
 shopt -s nullglob
 
-files=($BASHER_PACKAGES_PATH/$package/man/*)
+files=("$BASHER_PACKAGES_PATH/$package"/man/*)
 files=("${files[@]##*/}")
 
 pattern="\.([1-9])\$"

--- a/libexec/basher-_unlink-bins
+++ b/libexec/basher-_unlink-bins
@@ -4,12 +4,12 @@ package="$1"
 
 if [ -e "$BASHER_PACKAGES_PATH/$package/package.sh" ]; then
   source "$BASHER_PACKAGES_PATH/$package/package.sh"
-  IFS=: read -a bins <<< "$BINS"
+  IFS=: read -ra bins <<< "$BINS"
 fi
 
 if [ -z "$bins" ]; then
   if [ -e "$BASHER_PACKAGES_PATH/$package/bin" ]; then
-    bins=($BASHER_PACKAGES_PATH/$package/bin/*)
+    bins=("$BASHER_PACKAGES_PATH/$package"/bin/*)
     bins=("${bins[@]##*/}")
     bins=("${bins[@]/#/bin/}")
   else

--- a/libexec/basher-_unlink-completions
+++ b/libexec/basher-_unlink-completions
@@ -9,8 +9,8 @@ fi
 shopt -s nullglob
 
 source "$BASHER_PACKAGES_PATH/$package/package.sh" # TODO: make this secure?
-IFS=: read -a bash_completions <<< "$BASH_COMPLETIONS"
-IFS=: read -a zsh_completions <<< "$ZSH_COMPLETIONS"
+IFS=: read -ra bash_completions <<< "$BASH_COMPLETIONS"
+IFS=: read -ra zsh_completions <<< "$ZSH_COMPLETIONS"
 
 for completion in "${bash_completions[@]}"
 do

--- a/libexec/basher-_unlink-man
+++ b/libexec/basher-_unlink-man
@@ -6,7 +6,7 @@ package="$1"
 
 shopt -s nullglob
 
-files=($BASHER_PACKAGES_PATH/$package/man/*)
+files=("$BASHER_PACKAGES_PATH/$package"/man/*)
 files=("${files[@]##*/}")
 
 pattern="\.([1-9])\$"

--- a/libexec/basher-help
+++ b/libexec/basher-help
@@ -77,7 +77,8 @@ collect_documentation() {
 }
 
 documentation_for() {
-  local filename="$(command_path "$1")"
+  local filename=
+  filename="$(command_path "$1")"
   if [ -n "$filename" ]; then
     extract_initial_comment_block < "$filename" | collect_documentation
   fi

--- a/libexec/basher-list
+++ b/libexec/basher-list
@@ -12,7 +12,7 @@ fi
 
 shopt -s nullglob
 
-for package_path in ${BASHER_PACKAGES_PATH}/*/*
+for package_path in "${BASHER_PACKAGES_PATH}"/*/*
 do
   username="$(dirname "$package_path")"
   username="${username##*/}"

--- a/libexec/basher-outdated
+++ b/libexec/basher-outdated
@@ -13,7 +13,7 @@ for package in "${packages[@]}"
 do
   package_path="$BASHER_PACKAGES_PATH/$package"
   if [ ! -L "$package_path" ]; then
-    cd $package_path
+    cd "$package_path"
     git remote update > /dev/null 2>&1
     if git symbolic-ref --short -q HEAD > /dev/null; then
         if [ "$(git rev-list --count HEAD...HEAD@{upstream})" -gt 0 ]; then


### PR DESCRIPTION
This fixes some Bash constructs to be more compatible / correct, as suggested by ShellCheck

Mainly, it
 
- Uses `$PWD` instead of `$(pwd)` for execution speed
- Use `-r` for `read` to prevent mangling of backslashes
- Properly quote variables where relevant