### PR TITLE
feat: adds descriptive error messages for link

### DIFF
--- a/libexec/basher-link
+++ b/libexec/basher-link
@@ -42,11 +42,15 @@ fi
 IFS=/ read -r namespace name <<< "$package"
 
 if [ -z "$namespace" ]; then
+  echo "Missing <namespace> from package '$package', <namespace>/<name>"
+  echo
   basher-help link
   exit 1
 fi
 
 if [ -z "$name" ]; then
+  echo "Missing <name> from package '$package', <namespace>/<name>"
+  echo
   basher-help link
   exit 1
 fi

--- a/tests/basher-link.bats
+++ b/tests/basher-link.bats
@@ -44,10 +44,12 @@ resolve_link() {
 
   run basher-link package1 namespace1/
   assert_failure
+  assert_line "Missing <name> from package 'namespace1/', <namespace>/<name>"
   assert_line "Usage: basher link [--no-deps] <directory> <package>"
 
   run basher-link package1 /package1
   assert_failure
+  assert_line "Missing <namespace> from package '/package1', <namespace>/<name>"
   assert_line "Usage: basher link [--no-deps] <directory> <package>"
 }
 


### PR DESCRIPTION
For example
```zsh
% basher link package1 /package1
Missing <namespace> from package '/package1', <namespace>/<name>

Usage: basher link [--no-deps] <directory> <package>

Installs a local directory as a basher package

```