### PR TITLE
implemented 'basher upgrade --all'

### DIFF
--- a/libexec/basher-upgrade
+++ b/libexec/basher-upgrade
@@ -14,6 +14,15 @@ if [ "$1" == "--complete" ]; then
   exec basher-list
 fi
 
+if [ "$1" == "--all" ]; then
+  basher-outdated |
+    while read -r package; do
+      echo "# $package"
+      basher-upgrade "$package"
+    done
+    exit 0
+fi
+
 package="$1"
 
 if [ -z "$package" ]; then


### PR DESCRIPTION
minimal implementation, although I could delete the 
`echo "# $package"`
if that's too much output.

if I don't put that echo, the output is just a concatenation of `git pull` outputs, and you can't easily see where one stops and the next one starts