### PR TITLE
Add realpath for relative symlinks

### DIFF
--- a/libexec/basher-_link-bins
+++ b/libexec/basher-_link-bins
@@ -27,6 +27,6 @@ do
     name="${name%%.*}"
   fi
   mkdir -p "$BASHER_INSTALL_BIN"
-  ln -sf "$BASHER_PACKAGES_PATH/$package/$bin" "$BASHER_INSTALL_BIN/${name}"
+  ln -sf $(realpath -s --relative-to="$BASHER_INSTALL_BIN" "$BASHER_PACKAGES_PATH/$package/$bin") "$BASHER_INSTALL_BIN/${name}"
   chmod +x "$BASHER_INSTALL_BIN/${name}"
 done

--- a/libexec/basher-_link-completions
+++ b/libexec/basher-_link-completions
@@ -15,7 +15,7 @@ IFS=: read -ra zsh_completions <<< "$ZSH_COMPLETIONS"
 for completion in "${bash_completions[@]}"
 do
   mkdir -p "$BASHER_PREFIX/completions/bash"
-  ln -sf "$BASHER_PACKAGES_PATH/$package/$completion" "$BASHER_PREFIX/completions/bash/${completion##*/}"
+  ln -sf $(realpath -s --relative-to="$BASHER_PREFIX/completions/bash" "$BASHER_PACKAGES_PATH/$package/$completion") "$BASHER_PREFIX/completions/bash/${completion##*/}"
 done
 
 for completion in "${zsh_completions[@]}"
@@ -23,9 +23,9 @@ do
   target="$BASHER_PACKAGES_PATH/$package/$completion"
   if grep -q "#compdef" "$target"; then
     mkdir -p "$BASHER_PREFIX/completions/zsh/compsys"
-    ln -sf "$target" "$BASHER_PREFIX/completions/zsh/compsys/${completion##*/}"
+    ln -sf $(realpath -s --relative-to="$BASHER_PREFIX/completions/zsh/compsys" "$target") "$BASHER_PREFIX/completions/zsh/compsys/${completion##*/}"
   else
     mkdir -p "$BASHER_PREFIX/completions/zsh/compctl"
-    ln -sf "$target" "$BASHER_PREFIX/completions/zsh/compctl/${completion##*/}"
+    ln -sf $(realpath -s --relative-to="$BASHER_PREFIX/completions/zsh/compctl" "$target") "$BASHER_PREFIX/completions/zsh/compctl/${completion##*/}"
   fi
 done

--- a/libexec/basher-_link-man
+++ b/libexec/basher-_link-man
@@ -16,6 +16,6 @@ do
   if [[ "$file" =~ $pattern ]]; then
     n="${BASH_REMATCH[1]}"
     mkdir -p "${BASHER_INSTALL_MAN}/man${n}"
-    ln -sf "$BASHER_PACKAGES_PATH/$package/man/$file" "$BASHER_INSTALL_MAN/man${n}/${file}"
+    ln -sf $(realpath -s --relative-to="$BASHER_INSTALL_MAN/man${n}" "$BASHER_PACKAGES_PATH/$package/man/$file") "$BASHER_INSTALL_MAN/man${n}/${file}"
   fi
 done


### PR DESCRIPTION
Replace generating symlinks from absolute to relative path.
Now symlinks from $BASHER_PREFIX/{man,bin,completions} are relative to $BASHER_PACKAGES_PATH/package.

Why?
I copy/rsync basher to VMs via ansible. This way, I can also copy installed packages. And I don't have internet access on all machines.