### PR TITLE
Add list of executables to verbose list

### DIFF
--- a/libexec/basher-list
+++ b/libexec/basher-list
@@ -28,5 +28,42 @@ do
     echo "$username/$package"
   else
     printf "%-30s %-30s\n" "$username/$package" "($(git --git-dir=${BASHER_PACKAGES_PATH}/$username/$package/.git config --get remote.origin.url))"
+    
+    # Find and display executables for this package
+    package_full="$username/$package"
+    bins=()
+    
+    # Check for package.sh file with custom BINS
+    if [ -e "$BASHER_PACKAGES_PATH/$package_full/package.sh" ]; then
+      source "$BASHER_PACKAGES_PATH/$package_full/package.sh"
+      IFS=: read -ra bins <<< "$BINS"
+    fi
+    
+    # If no custom bins, look for executables
+    if [ -z "$bins" ]; then
+      if [ -e "$BASHER_PACKAGES_PATH/$package_full/bin" ]; then
+        bins=("$BASHER_PACKAGES_PATH/$package_full"/bin/*)
+        bins=("${bins[@]##*/}")
+        bins=("${bins[@]/#/bin/}")
+      else
+        bins=($(find "$BASHER_PACKAGES_PATH/$package_full" -maxdepth 1 -mindepth 1 -perm -u+x -type f -or -type l 2>/dev/null))
+        bins=("${bins[@]##*/}")
+      fi
+    fi
+    
+    # Display executables if any exist
+    if [ ${#bins[@]} -gt 0 ] && [ -n "${bins[0]}" ]; then
+      echo "  Executables:"
+      for bin in "${bins[@]}"; do
+        name="${bin##*/}"
+        if ${REMOVE_EXTENSION:-false}; then
+          name="${name%%.*}"
+        fi
+        if [ -n "$name" ]; then
+          echo "    - $name"
+        fi
+      done
+    fi
+    echo  # Add blank line between packages
   fi
 done

--- a/libexec/basher-list
+++ b/libexec/basher-list
@@ -53,17 +53,15 @@ do
     
     # Display executables if any exist
     if [ ${#bins[@]} -gt 0 ] && [ -n "${bins[0]}" ]; then
-      echo "  Executables:"
       for bin in "${bins[@]}"; do
         name="${bin##*/}"
         if ${REMOVE_EXTENSION:-false}; then
           name="${name%%.*}"
         fi
         if [ -n "$name" ]; then
-          echo "    - $name"
+          echo "- $name"
         fi
       done
     fi
-    echo  # Add blank line between packages
   fi
 done

--- a/tests/basher-list.bats
+++ b/tests/basher-list.bats
@@ -53,10 +53,8 @@ load test_helper
   
   # Check exact output format
   assert_line --index 0 --regexp "username/package +\(${BASHER_ORIGIN_DIR}/username/package\)"
-  assert_line --index 1 "  Executables:"
-  assert_line --index 2 "    - tool1"
-  assert_line --index 3 "    - tool2.sh"
-  assert_line --index 4 ""  # blank line
+  assert_line --index 1 "- tool1"
+  assert_line --index 2 "- tool2.sh"
 }
 
 @test "verbose flag with multiple packages shows each with executables" {
@@ -87,13 +85,9 @@ load test_helper
   assert_output --partial "user3/pkg3"
   
   # Verify executables are shown
-  assert_output --partial "    - cmd1"
-  assert_output --partial "    - cmd2"
-  assert_output --partial "    - cmd3"
-  
-  # Verify each package with executables has the header
-  local exec_headers=$(echo "$output" | grep -c "  Executables:")
-  assert_equal "$exec_headers" "2"  # Only 2 packages have executables
+  assert_output --partial "- cmd1"
+  assert_output --partial "- cmd2"
+  assert_output --partial "- cmd3"
 }
 
 @test "verbose flag respects REMOVE_EXTENSION config" {
@@ -108,8 +102,8 @@ load test_helper
   assert_success
   
   # Should show names without extensions
-  assert_output --partial "    - script"
-  assert_output --partial "    - tool"
+  assert_output --partial "- script"
+  assert_output --partial "- tool"
   
   # Should NOT show the extensions
   refute_output --partial "script.sh"

--- a/tests/basher-list.bats
+++ b/tests/basher-list.bats
@@ -23,21 +23,6 @@ load test_helper
   refute_line "username2/p3"
 }
 
-@test "list installed packages with verbose flag shows remote URLs" {
-  mock_clone
-  create_package username/p1
-  create_package username2/p2
-  basher-install username/p1
-  basher-install username2/p2
-  
-  run basher-list -v
-  assert_success
-  # Check that output contains package names in the verbose format
-  # The format is: package-name (remote-url)
-  assert_output --regexp "username/p1 +\(${BASHER_ORIGIN_DIR}/username/p1\)"
-  assert_output --regexp "username2/p2 +\(${BASHER_ORIGIN_DIR}/username2/p2\)"
-}
-
 @test "verbose flag with arguments shows usage" {
   run basher-list -v extra_arg
   assert_failure
@@ -54,4 +39,59 @@ load test_helper
   run basher-list -v
   assert_success
   assert_output ""
+}
+
+@test "verbose flag shows complete output format for single package" {
+  mock_clone
+  create_package username/package
+  create_exec username/package tool1
+  create_exec username/package tool2.sh
+  basher-install username/package
+  
+  run basher-list -v
+  assert_success
+  
+  # Check exact output format
+  assert_line --index 0 --regexp "username/package +\(${BASHER_ORIGIN_DIR}/username/package\)"
+  assert_line --index 1 "  Executables:"
+  assert_line --index 2 "    - tool1"
+  assert_line --index 3 "    - tool2.sh"
+  assert_line --index 4 ""  # blank line
+}
+
+@test "verbose flag with multiple packages shows each with executables" {
+  mock_clone
+  
+  # First package with executables
+  create_package user1/pkg1
+  create_exec user1/pkg1 cmd1
+  basher-install user1/pkg1
+  
+  # Second package with different executables
+  create_package user2/pkg2
+  create_exec user2/pkg2 cmd2
+  create_exec user2/pkg2 cmd3
+  basher-install user2/pkg2
+  
+  # Third package without executables
+  create_package user3/pkg3
+  echo "readme" > "$BASHER_ORIGIN_DIR/user3/pkg3/README"
+  basher-install user3/pkg3
+  
+  run basher-list -v
+  assert_success
+  
+  # Verify all packages are listed
+  assert_output --partial "user1/pkg1"
+  assert_output --partial "user2/pkg2"
+  assert_output --partial "user3/pkg3"
+  
+  # Verify executables are shown
+  assert_output --partial "    - cmd1"
+  assert_output --partial "    - cmd2"
+  assert_output --partial "    - cmd3"
+  
+  # Verify each package with executables has the header
+  local exec_headers=$(echo "$output" | grep -c "  Executables:")
+  assert_equal "$exec_headers" "2"  # Only 2 packages have executables
 }

--- a/tests/basher-list.bats
+++ b/tests/basher-list.bats
@@ -95,3 +95,23 @@ load test_helper
   local exec_headers=$(echo "$output" | grep -c "  Executables:")
   assert_equal "$exec_headers" "2"  # Only 2 packages have executables
 }
+
+@test "verbose flag respects REMOVE_EXTENSION config" {
+  mock_clone
+  create_package username/package
+  create_exec username/package script.sh
+  create_exec username/package tool.py
+  set_remove_extension username/package true
+  basher-install username/package
+  
+  run basher-list -v
+  assert_success
+  
+  # Should show names without extensions
+  assert_output --partial "    - script"
+  assert_output --partial "    - tool"
+  
+  # Should NOT show the extensions
+  refute_output --partial "script.sh"
+  refute_output --partial "tool.py"
+}


### PR DESCRIPTION
Sometimes I forget the executable names for packages I've installed with basher or there might be multiple executables. So I added a printout similar to how the `uv` package manger handles `uv tool list`.

Example output:
```
$ basher list -v
bats-core/bats                 (https://github.com/sstephenson/bats.git)
- bats
```