### PR TITLE
avoid potential arbitrary code execution from package.sh

### DIFF
--- a/libexec/basher-_deps
+++ b/libexec/basher-_deps
@@ -10,6 +10,13 @@
 
 set -e
 
+get_vars_from_file() {
+  local names_pattern="$1";shift
+  local content_pattern='[a-zA-Z0-9.:/_-]*'
+  local value_pattern='('"$content_pattern"'|'\'"$content_pattern"\''|"'"$content_pattern"'")'
+  grep -E '^'"$names_pattern"'='"$value_pattern"'$' "$@"
+}
+
 if [ "$#" -ne 1 ]; then
   basher-help _deps
   exit 1
@@ -23,7 +30,7 @@ fi
 
 shopt -s nullglob
 
-source "$BASHER_PACKAGES_PATH/$package/package.sh"
+eval "$(get_vars_from_file 'DEPS' "$BASHER_PACKAGES_PATH/$package/package.sh")"
 IFS=: read -ra deps <<< "$DEPS"
 
 for dep in "${deps[@]}"

--- a/libexec/basher-_link-bins
+++ b/libexec/basher-_link-bins
@@ -2,10 +2,17 @@
 
 package="$1"
 
+get_vars_from_file() {
+  local names_pattern="$1";shift
+  local content_pattern='[a-zA-Z0-9.:/_-]*'
+  local value_pattern='('"$content_pattern"'|'\'"$content_pattern"\''|"'"$content_pattern"'")'
+  grep -E '^'"$names_pattern"'='"$value_pattern"'$' "$@"
+}
+
 shopt -s nullglob
 
 if [ -e "$BASHER_PACKAGES_PATH/$package/package.sh" ]; then
-  source "$BASHER_PACKAGES_PATH/$package/package.sh"
+  eval "$(get_vars_from_file 'BINS' "$BASHER_PACKAGES_PATH/$package/package.sh")"
   IFS=: read -ra bins <<< "$BINS"
 fi
 

--- a/libexec/basher-_link-completions
+++ b/libexec/basher-_link-completions
@@ -2,13 +2,20 @@
 
 package="$1"
 
+get_vars_from_file() {
+  local names_pattern="$1";shift
+  local content_pattern='[a-zA-Z0-9.:/_-]*'
+  local value_pattern='('"$content_pattern"'|'\'"$content_pattern"\''|"'"$content_pattern"'")'
+  grep -E '^'"$names_pattern"'='"$value_pattern"'$' "$@"
+}
+
 if [ ! -e "$BASHER_PACKAGES_PATH/$package/package.sh" ]; then
   exit
 fi
 
 shopt -s nullglob
 
-source "$BASHER_PACKAGES_PATH/$package/package.sh" # TODO: make this secure?
+eval "$(get_vars_from_file '(BASH_COMPLETIONS|ZSH_COMPLETIONS)' "$BASHER_PACKAGES_PATH/$package/package.sh")"
 IFS=: read -ra bash_completions <<< "$BASH_COMPLETIONS"
 IFS=: read -ra zsh_completions <<< "$ZSH_COMPLETIONS"
 

--- a/libexec/basher-_unlink-bins
+++ b/libexec/basher-_unlink-bins
@@ -2,8 +2,15 @@
 
 package="$1"
 
+get_vars_from_file() {
+  local names_pattern="$1";shift
+  local content_pattern='[a-zA-Z0-9.:/_-]*'
+  local value_pattern='('"$content_pattern"'|'\'"$content_pattern"\''|"'"$content_pattern"'")'
+  grep -E '^'"$names_pattern"'='"$value_pattern"'$' "$@"
+}
+
 if [ -e "$BASHER_PACKAGES_PATH/$package/package.sh" ]; then
-  source "$BASHER_PACKAGES_PATH/$package/package.sh"
+  eval "$(get_vars_from_file 'BINS' "$BASHER_PACKAGES_PATH/$package/package.sh")"
   IFS=: read -ra bins <<< "$BINS"
 fi
 

--- a/libexec/basher-_unlink-completions
+++ b/libexec/basher-_unlink-completions
@@ -2,13 +2,20 @@
 
 package="$1"
 
+get_vars_from_file() {
+  local names_pattern="$1";shift
+  local content_pattern='[a-zA-Z0-9.:/_-]*'
+  local value_pattern='('"$content_pattern"'|'\'"$content_pattern"\''|"'"$content_pattern"'")'
+  grep -E '^'"$names_pattern"'='"$value_pattern"'$' "$@"
+}
+
 if [ ! -e "$BASHER_PACKAGES_PATH/$package/package.sh" ]; then
   exit
 fi
 
 shopt -s nullglob
 
-source "$BASHER_PACKAGES_PATH/$package/package.sh" # TODO: make this secure?
+eval "$(get_vars_from_file '(BASH_COMPLETIONS|ZSH_COMPLETIONS)' "$BASHER_PACKAGES_PATH/$package/package.sh")"
 IFS=: read -ra bash_completions <<< "$BASH_COMPLETIONS"
 IFS=: read -ra zsh_completions <<< "$ZSH_COMPLETIONS"
 

--- a/libexec/basher-list
+++ b/libexec/basher-list
@@ -5,6 +5,13 @@
 
 set -e
 
+get_vars_from_file() {
+  local names_pattern="$1";shift
+  local content_pattern='[a-zA-Z0-9.:/_-]*'
+  local value_pattern='('"$content_pattern"'|'\'"$content_pattern"\''|"'"$content_pattern"'")'
+  grep -E '^'"$names_pattern"'='"$value_pattern"'$' "$@"
+}
+
 case $1 in
   -v)
     verbose="true"
@@ -35,7 +42,7 @@ do
     
     # Check for package.sh file with custom BINS
     if [ -e "$BASHER_PACKAGES_PATH/$package_full/package.sh" ]; then
-      source "$BASHER_PACKAGES_PATH/$package_full/package.sh"
+      eval "$(get_vars_from_file 'BINS' "$BASHER_PACKAGES_PATH/$package_full/package.sh")"
       IFS=: read -ra bins <<< "$BINS"
     fi
     


### PR DESCRIPTION
I'm trying to avoid arbitrary code execution from package.sh file.

We can extract the value with restricted pattern.
It avoid any arbitrary code execution.

Allowed variables seems only : BINS, DEPS, BASH_COMPLETIONS, ZSH_COMPLETIONS.
I only see simple static values.
Tested from all known basher repositories.

$ ls -1 packages/ | wc -l
101
$ find packages/ -maxdepth 2 -name 'package.sh' -exec grep -Hn '^[^#]\+' {} \;|sort
packages/benv/package.sh:1:BASH_COMPLETIONS=benv.completions
packages/dotenv/package.sh:1:BINS=dotenv
packages/dotenv/package.sh:2:BUILD_DEPS=bashup/mdsh
packages/gitea-cli/package.sh:1:BINS=bin/gitea
packages/git-identity/package.sh:4:BINS='git-identity'
packages/git-identity/package.sh:6:BASH_COMPLETIONS='git-identity.bash-completion'
packages/git-identity/package.sh:8:ZSH_COMPLETIONS='git-identity.zsh-completion'
packages/jqmd/package.sh:1:BINS=bin/jqmd
packages/mdsh/package.sh:1:BINS=bin/mdsh
packages/shelldemo/package.sh:1:BINS="bin/shelldemo"
packages/shelldemo/package.sh:2:DEPS="gitlab.com/shellm/core"
packages/shelldemo/package.sh:3:BASH_COMPLETIONS="cmp/shelldemo.completion.bash"
packages/shelldemo/package.sh:4:ZSH_COMPLETIONS="cmp/shelldemo.completion.zsh"

I don't know if it is the better solution but it is one way to do.

Regards,